### PR TITLE
use zef instead of panda in travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ language: perl6
 perl6:
   - latest
 install:
-  - rakudobrew build-panda
+  - rakudobrew build-zef
   - gcc -o pngcheck pngcheck.c
 script:
-  - panda install .
+  - zef install .
   - perl6 camelia.p6
   - ./pngcheck camelia.png


### PR DESCRIPTION
since it's been kicked out from rakudobrew

(i made this a long time ago, then apparently forgot to PR the change)